### PR TITLE
Add an alias in torchs mod to use torch in game.

### DIFF
--- a/mods/torches/init.lua
+++ b/mods/torches/init.lua
@@ -1,3 +1,7 @@
+
+--Use default torch in game 
+minetest.register_alias("default:torch", "torches:torch")
+
 local VIEW_DISTANCE = 13 
 
 local null = {x=0, y=0, z=0}


### PR DESCRIPTION
When I test your subgame, i can't craft a torch. I propose you a little change in torchs mod to allow player crafting the default torchs.
